### PR TITLE
Fix schema owned model returning "schema error"

### DIFF
--- a/src/utils/ai/text/index.ts
+++ b/src/utils/ai/text/index.ts
@@ -41,13 +41,13 @@ const buildOptions = async (input: AIInput<any>, config: AIConfig = {}) => {
   const outputBuilders: Record<string, (schema: any) => any> = {
     schema: (s) => {
       const schemaPrompt = `\n请按照以下 schema 格式返回结果:\n${JSON.stringify(
-      z.toJSONSchema(z.object(s)),
-      null,
-      2,
-    )}\n请输出JSON格式，只返回结果，不要将Schema返回。`;
-    input.system = (input.system ?? "") + schemaPrompt;
-    // 返回验证模式
-    return Output.object({ schema: z.object(s) });
+        z.toJSONSchema(z.object(s)),
+        null,
+        2,
+      )}\n请输出JSON格式，只返回结果，不要将Schema返回。`;
+      input.system = (input.system ?? "") + schemaPrompt;
+      // 返回验证模式
+      return Output.object({ schema: z.object(s) });
     },
     object: () => {
       const jsonSchemaPrompt = `\n请按照以下 JSON Schema 格式返回结果:\n${JSON.stringify(


### PR DESCRIPTION
解决QWEN如果不在提示词中包括JSON，body中要求"response_format":{"type":"json_object"}会报错的问题。
解决Owned模型中responseFormat为schema的通用问题，导致提示词中未提供schema而返回内容不匹配的问题。