### PR TITLE
fix: create missing t_myTasks and t_taskList database tables

### DIFF
--- a/src/lib/fixDB.ts
+++ b/src/lib/fixDB.ts
@@ -24,6 +24,36 @@ export default async (knex: Knex): Promise<void> => {
     }
   };
 
+  //创建缺失的表
+  if (!(await knex.schema.hasTable("t_myTasks"))) {
+    await knex.schema.createTable("t_myTasks", (table) => {
+      table.integer("id").notNullable();
+      table.integer("projectId");
+      table.string("taskClass");
+      table.string("relatedObjects");
+      table.string("model");
+      table.text("describe");
+      table.string("state");
+      table.integer("startTime");
+      table.text("reason");
+      table.primary(["id"]);
+      table.unique(["id"]);
+    });
+  }
+  if (!(await knex.schema.hasTable("t_taskList"))) {
+    await knex.schema.createTable("t_taskList", (table) => {
+      table.integer("id").notNullable();
+      table.text("name");
+      table.integer("projectName");
+      table.text("prompt");
+      table.string("state");
+      table.string("startTime");
+      table.string("endTime");
+      table.primary(["id"]);
+      table.unique(["id"]);
+    });
+  }
+
   //添加字段
   await addColumn("t_video", "time", "integer");
   await addColumn("t_video", "aiConfigId", "integer");

--- a/src/lib/initDB.ts
+++ b/src/lib/initDB.ts
@@ -195,23 +195,38 @@ export default async (knex: Knex, forceInit: boolean = false): Promise<void> => 
       },
       initData: async (knex) => {},
     },
-    // {
-    //   name: "t_myTasks",
-    //   builder: (table) => {
-    //     table.integer("id").notNullable();
-    //     table.integer("projectId");
-    //     table.string("taskClass");
-    //     table.string("relatedObjects");
-    //     table.string("model");
-    //     table.text("describe");
-    //     table.string("state");
-    //     table.integer("startTime");
-    //     table.text("reason");
-    //     table.primary(["id"]);
-    //     table.unique(["id"]);
-    //   },
-    //   initData: async (knex) => {},
-    // },
+    {
+      name: "t_myTasks",
+      builder: (table) => {
+        table.integer("id").notNullable();
+        table.integer("projectId");
+        table.string("taskClass");
+        table.string("relatedObjects");
+        table.string("model");
+        table.text("describe");
+        table.string("state");
+        table.integer("startTime");
+        table.text("reason");
+        table.primary(["id"]);
+        table.unique(["id"]);
+      },
+      initData: async (knex) => {},
+    },
+    {
+      name: "t_taskList",
+      builder: (table) => {
+        table.integer("id").notNullable();
+        table.text("name");
+        table.integer("projectName");
+        table.text("prompt");
+        table.string("state");
+        table.string("startTime");
+        table.string("endTime");
+        table.primary(["id"]);
+        table.unique(["id"]);
+      },
+      initData: async (knex) => {},
+    },
     {
       name: "t_artStyle",
       builder: (table) => {

--- a/src/routes/project/delProject.ts
+++ b/src/routes/project/delProject.ts
@@ -27,7 +27,7 @@ export default router.post(
     await u.db("t_novel").where("projectId", id).delete();
     await u.db("t_storyline").where("projectId", id).delete();
     await u.db("t_outline").where("projectId", id).delete();
-    // await u.db("t_myTasks").where("projectId", id).delete();
+    await u.db("t_myTasks").where("projectId", id).delete();
 
     await u.db("t_script").where("projectId", id).delete();
     await u.db("t_assets").where("projectId", id).delete();


### PR DESCRIPTION
Fixes #75

## Problem

The `t_myTasks` table was commented out in `initDB.ts`, but the following routes still query it:
- `task/getMyTaskApi` — queries the task list
- `task/getTaskCategories` — queries tasks by category

When users access "My Projects" related features, SQLite throws a `no such table: t_myTasks` error because it cannot find the `t_myTasks` table.

Similarly, the `t_taskList` table queried by the `task/taskDetails` route was also not defined in `initDB.ts`.

## Fix

1. **`src/lib/initDB.ts`**: Restore the `t_myTasks` table definition (uncomment) and add the `t_taskList` table definition
2. **`src/lib/fixDB.ts`**: Add migration logic to automatically create the two missing tables for existing database users
3. **`src/routes/project/delProject.ts`**: Uncomment the logic for cleaning up `t_myTasks` records when deleting a project

## Testing

- New users: Both tables are automatically created during the `initDB` phase
- Existing users: The `fixDB` migration detects and creates missing tables without affecting existing data
- When deleting a project, related `t_myTasks` records are properly cleaned up