### PR TITLE
fix: fall back to asset's stored prompt/intro when request prompt is empty

### DIFF
--- a/src/routes/assets/generateAssets.ts
+++ b/src/routes/assets/generateAssets.ts
@@ -34,10 +34,17 @@ export default router.post(
     projectId: z.number(),
     name: z.string(),
     base64: z.string().optional().nullable(),
-    prompt: z.string(),
+    prompt: z.string().optional().default(""),
   }),
   async (req, res) => {
-    const { id, type, projectId, base64, prompt, name } = req.body;
+    const { id, type, projectId, base64, name } = req.body;
+    let prompt: string = req.body.prompt || "";
+
+    // If prompt is empty, fall back to the asset's stored prompt or intro from the database
+    if (!prompt) {
+      const asset = await u.db("t_assets").where("id", id).select("prompt", "intro").first();
+      prompt = asset?.prompt || asset?.intro || "";
+    }
 
     //获取风格
     const project = await u.db("t_project").where("id", projectId).select("artStyle", "type", "intro", "videoRatio").first();


### PR DESCRIPTION
Fixes #83

## Problem

When generating derived asset images (角色/场景/道具), if the frontend sends an empty `prompt` field (or sends `desc` instead of `prompt` as reported in issue comments), the `generateAssets` endpoint would accept the empty string (since `z.string()` does not enforce non-empty), resulting in the AI image generation running with no meaningful prompt context — causing generation failures or unusable output.

## Solution

- Made `prompt` optional in the request validation (`z.string().optional().default("")`)
- Added automatic fallback: when `prompt` is empty, the handler looks up the asset record by `id` and uses the stored `prompt` or `intro` field from the database as the effective prompt

This ensures derived assets (whose `intro`/`prompt` fields are populated from outline data) can be regenerated even when the frontend omits or sends an empty prompt.

## Testing

- Send a `POST /assets/generateAssets` request with `prompt: ""` for an asset that has a non-empty `intro` in the database — generation should proceed using the stored description
- Send a `POST /assets/generateAssets` request with a non-empty `prompt` — behavior unchanged