### PR TITLE
fix: add missing associationSkills field to video model schema in addVendor.ts

### DIFF
--- a/src/routes/setting/vendorConfig/addVendor.ts
+++ b/src/routes/setting/vendorConfig/addVendor.ts
@@ -47,6 +47,7 @@ const vendorConfigSchema = z.object({
             z.array(z.enum(["videoReference", "imageReference", "audioReference", "textReference"])),
           ]),
         ),
+        associationSkills: z.string().optional(),
         audio: z.union([z.literal("optional"), z.boolean()]),
         durationResolutionMap: z.array(
           z.object({


### PR DESCRIPTION
Fixes #86

## Problem
The video model schema in `addVendor.ts` was missing the `associationSkills` field in the backend validation whitelist. When adding a new vendor with a video model that has `associationSkills` configured, the parameter was silently dropped or caused validation inconsistencies compared to `updateVendor.ts` and `updateCode.ts`.

## Solution
Added `associationSkills: z.string().optional()` to the video model Zod schema in `addVendor.ts`, bringing it in line with the schemas in `updateVendor.ts` and `updateCode.ts`.

## Testing
- Compared the video model schemas across all three vendor config route files (`addVendor.ts`, `updateCode.ts`, `updateVendor.ts`) to confirm consistency after the fix.