### PR TITLE
fix(oss): make ossURL env override NODE_ENV=dev hardcode

### DIFF
--- a/src/utils/oss.ts
+++ b/src/utils/oss.ts
@@ -51,9 +51,9 @@ class OSS {
     const safePath = normalizeUserPath(userRelPath);
     // URL 始终使用 /，所以这里需要将系统分隔符转回 /
     let url = `/${prefix}/`;
-    if (process.env.ossURL && process.env.ossURL !== "") url = process.env.ossURL + `/${prefix}/`;
     if (process.env.NODE_ENV == "dev") url = `http://localhost:10588/${prefix}/`;
     if (isEletron()) url = `http://localhost:${process.env.PORT}/${prefix}/`;
+    if (process.env.ossURL && process.env.ossURL !== "") url = process.env.ossURL + `/${prefix}/`;
     return `${url}${safePath.split(path.sep).join("/")}`;
   }
 


### PR DESCRIPTION
## Problem

In [`src/utils/oss.ts:49-58`](src/utils/oss.ts#L49-L58), the `ossURL` env check sits **before** the `NODE_ENV=dev` hardcode, so the dev branch silently overrides any `ossURL` configured by the deployer. Combined with the dev branch hardcoding `localhost:10588` (instead of `process.env.PORT`), this makes it impossible to deploy toonflow as a containerized server in dev mode where the OSS URL needs to point to the public host.

```ts
let url = `/${prefix}/`;
if (process.env.ossURL && process.env.ossURL !== "") url = process.env.ossURL + `/${prefix}/`;
if (process.env.NODE_ENV == "dev") url = `http://localhost:10588/${prefix}/`;  // ← overrides ossURL
if (isEletron()) url = `http://localhost:${process.env.PORT}/${prefix}/`;
```

### Concrete failure

When toonflow runs in Docker (NODE_ENV=dev, container port 10588 mapped to host 9090) and the user opens the admin UI from a remote browser:
- `modelTest` returns image URL `http://localhost:10588/oss/testImage.jpg`
- Browser resolves `localhost:10588` against the user's own machine → 404
- "Test Result" modal pops up but `<img>` shows broken icon
- The image actually generated successfully and is reachable at `http://<host>:9090/oss/testImage.jpg`

## Fix

Reorder so `ossURL` is the last (highest-priority) check — explicit env override beats default behavior for any environment.

```diff
 let url = `/${prefix}/`;
-if (process.env.ossURL && process.env.ossURL !== "") url = process.env.ossURL + `/${prefix}/`;
 if (process.env.NODE_ENV == "dev") url = `http://localhost:10588/${prefix}/`;
 if (isEletron()) url = `http://localhost:${process.env.PORT}/${prefix}/`;
+if (process.env.ossURL && process.env.ossURL !== "") url = process.env.ossURL + `/${prefix}/`;
```

After this change, deployers set `-e ossURL=http://<public-host>:<port>` and the URL returned to the browser becomes reachable.

## Test plan

- [x] Local containerized deploy with `NODE_ENV=dev`, `ossURL=http://<public-host>:9090`
- [x] Trigger admin UI Provider test → modal renders the generated image (no broken icon)
- [x] `modelTest` API returns reachable URL: `http://<public-host>:9090/oss/testImage.jpg` HTTP 200
- [x] Default behavior unchanged when `ossURL` is unset (existing dev / electron paths still apply)

## Compatibility

- No breaking change. When `ossURL` is unset, behavior is identical to before.
- Electron path unchanged (electron deploys typically don't set `ossURL`).