### PR TITLE
fix: remove hardcoded localhost:10588 in getFileUrl for remote/Docker deployments

### DIFF
--- a/src/utils/oss.ts
+++ b/src/utils/oss.ts
@@ -51,9 +51,9 @@ class OSS {
     await this.ensureInit();
     const safePath = normalizeUserPath(userRelPath);
     // URL 始终使用 /，所以这里需要将系统分隔符转回 /
+    // 默认返回相对路径，由浏览器自动拼接当前访问域名，避免硬编码 localhost 导致远程访问时图片加载失败
     let url = `/${prefix}/`;
     if (process.env.ossURL && process.env.ossURL !== "") url = process.env.ossURL + `/${prefix}/`;
-    if (process.env.NODE_ENV == "dev") url = `http://localhost:10588/${prefix}/`;
     if (isEletron()) url = `http://localhost:${process.env.PORT}/${prefix}/`;
     return `${url}${safePath.split(path.sep).join("/")}`;
   }


### PR DESCRIPTION
## Problem

When deploying Toonflow via Docker and accessing from a remote machine, all image/resource URLs (story covers, materials, etc.) fail to load because `getFileUrl()` hardcodes `http://localhost:10588`.

**Root cause:** In `src/env.ts`, non-Electron environments always set `NODE_ENV = "dev"`, which triggers the hardcoded localhost branch in `getFileUrl()`:

```typescript
// src/utils/oss.ts line 56
if (process.env.NODE_ENV == "dev") url = `http://localhost:10588/${prefix}/`;
```

This works for local development but breaks when accessing from another machine (e.g., `http://192.168.1.100:10588`).

## Fix

Remove the `NODE_ENV == "dev"` branch and return relative paths (`/skills/...`, `/oss/...`) by default. The browser automatically resolves relative URLs against the current origin, so it works correctly for:
- Local access (`http://localhost:10588`)
- Remote access (`http://192.168.x.x:10588`)
- Any reverse proxy setup

The Electron path and `ossURL` env override remain unchanged.

## Changes

- `src/utils/oss.ts`: Remove hardcoded `http://localhost:10588` for dev mode, add comment explaining the relative-path strategy.