### PR TITLE
fix(build): use static import for router to fix production bundle

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import fs from "fs";
 import u from "@/utils";
 import jwt from "jsonwebtoken";
 import socketInit from "@/socket/index";
+import routerDefault from "@/router";
 import { isEletron } from "@/utils/getPath";
 
 const app = express();
@@ -117,8 +118,7 @@ export default async function startServe(randomPort: Boolean = false) {
     }
   });
 
-  const router = await import("@/router");
-  await router.default(app);
+  await routerDefault(app);
 
   // 404 处理
   app.use((_, res, next: NextFunction) => {


### PR DESCRIPTION
## Bug

When building for production with `yarn build` (esbuild), all API routes return **404 Not Found** except for the 13 hardcoded middleware routes (`/oss`, `/assets`, etc.).

## Root Cause

In `src/app.ts`, the router is loaded via a **dynamic import**:

```ts
const router = await import('@/router');
await router.default(app);
```

esbuild does not bundle dynamic `import()` calls with path aliases like `@/router`. As a result, the compiled `data/serve/app.js` does not include any of the 167 route handlers from `src/router.ts`, causing all API endpoints to return 404 in production.

## Fix

Replace the dynamic import with a **static import** at the top of the file:

```ts
// Before
const router = await import('@/router');
await router.default(app);

// After
import routerDefault from '@/router';
...
await routerDefault(app);
```

This ensures esbuild bundles all 167 route handlers into `data/serve/app.js` during `yarn build`.

## Impact

- **Production builds** (`yarn build && yarn start`): all API routes now work correctly
- **Docker deployments**: no longer need to run in dev mode as a workaround
- **Development mode** (`yarn dev`): unaffected, works the same

## Files Changed

- `src/app.ts` — 2 lines changed (static import + remove dynamic import)