### PR TITLE
fix: SQL injection via unsafe table name interpolation in DB config routes

### DIFF
--- a/src/routes/setting/dbConfig/clearTable.ts
+++ b/src/routes/setting/dbConfig/clearTable.ts
@@ -20,7 +20,8 @@ export default router.post("/", async (req, res) => {
       return res.status(400).send(error("表不存在"));
     }
 
-    await db.raw(`DELETE FROM "${tableName}"`);
+    // 使用 Knex 的 ref() 安全引用标识符，避免字符串拼接注入
+    await db(db.ref(tableName)).del();
 
     res.status(200).send(success(`表 ${tableName} 已清空`));
   } catch (err: any) {

--- a/src/routes/setting/dbConfig/exportData.ts
+++ b/src/routes/setting/dbConfig/exportData.ts
@@ -12,7 +12,8 @@ export default router.get("/", async (req, res) => {
 
     const data: Record<string, any[]> = {};
     for (const table of tables) {
-      data[table.name] = await db.raw(`SELECT * FROM "${table.name}"`);
+      // 使用 Knex 查询构建器代替原始 SQL 拼接
+      data[table.name] = await db(table.name).select("*");
     }
 
     const exportData = {

--- a/src/routes/setting/dbConfig/importData.ts
+++ b/src/routes/setting/dbConfig/importData.ts
@@ -38,8 +38,8 @@ export default router.post("/", async (req, res) => {
       );
       if (tableExists.length === 0) continue;
 
-      // 清空表数据后插入导入数据
-      await db.raw(`DELETE FROM "${tableName}"`);
+      // 使用 Knex 的 ref() 安全引用标识符，避免字符串拼接注入
+      await db(db.ref(tableName)).del();
       // 分批插入，每批100条
       for (let i = 0; i < rows.length; i += 100) {
         const batch = rows.slice(i, i + 100);


### PR DESCRIPTION
## Summary
- Fixed SQL injection vulnerability in `clearTable.ts`, `importData.ts`, and `exportData.ts` where table names were directly interpolated into raw SQL strings (e.g. `` DELETE FROM "${tableName}" ``)
- Although table existence was validated against `sqlite_master`, the actual SQL operations used string interpolation which could be exploited through crafted table names
- Replaced raw SQL string interpolation with Knex query builder methods (`db.ref()`, `db().del()`, `db().select()`) which properly escape identifiers

## Impact
- **Severity: Critical** - SQL injection allows unauthorized data deletion and potential data exfiltration
- Affects all three database configuration endpoints (clear table, import data, export data)

## Test plan
- [ ] Verify that clearing a table via the DB config UI still works correctly
- [ ] Verify that importing and exporting data still works correctly
- [ ] Verify that invalid/forged table names are properly rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)