### PR TITLE
fix: socket.io disconnect handler causing TypeError and resource leak

### DIFF
--- a/src/socket/routes/productionAgent.ts
+++ b/src/socket/routes/productionAgent.ts
@@ -46,6 +46,14 @@ export default (nsp: Namespace) => {
       thinlLevel: 0,
     };
 
+    // 在 connection handler 内部监听 disconnect 事件
+    // nsp.on("disconnect") 的回调签名不接收 Socket 参数，会导致 socket.id 为 undefined
+    socket.on("disconnect", (reason) => {
+      console.log("[productionAgent] 已断开连接:", socket.id, "原因:", reason);
+      abortController?.abort();
+      abortController = null;
+    });
+
     socket.on("updateContext", (data: { isolationKey: string; projectId: number; scriptId: number }, callback) => {
       isolationKey = data.isolationKey;
       resTool = new ResTool(socket, {
@@ -97,8 +105,5 @@ export default (nsp: Namespace) => {
       abortController?.abort();
       abortController = null;
     });
-  });
-  nsp.on("disconnect", (socket: Socket) => {
-    console.log("[productionAgent] 已断开连接:", socket.id);
   });
 };

--- a/src/socket/routes/scriptAgent.ts
+++ b/src/socket/routes/scriptAgent.ts
@@ -45,6 +45,14 @@ export default (nsp: Namespace) => {
       thinlLevel: 0,
     };
 
+    // 在 connection handler 内部监听 disconnect 事件
+    // nsp.on("disconnect") 的回调签名不接收 Socket 参数，会导致 socket.id 为 undefined
+    socket.on("disconnect", (reason) => {
+      console.log("[scriptAgent] 已断开连接:", socket.id, "原因:", reason);
+      abortController?.abort();
+      abortController = null;
+    });
+
     socket.on("chat", async (data: { content: string }) => {
       const { content } = data;
       abortController?.abort();
@@ -87,8 +95,5 @@ export default (nsp: Namespace) => {
       abortController?.abort();
       abortController = null;
     });
-  });
-  nsp.on("disconnect", (socket: Socket) => {
-    console.log("[scriptAgent] 已断开连接:", socket.id);
   });
 };


### PR DESCRIPTION
## Summary
- Fixed incorrect disconnect handler registration in both `productionAgent.ts` and `scriptAgent.ts`
- The disconnect handler was registered on the Namespace (`nsp.on("disconnect")`) which does not pass a Socket argument, causing `socket.id` to be `undefined` and a TypeError at runtime
- Moved the disconnect handler inside the `connection` handler where `socket.on("disconnect")` works correctly with the socket instance in scope
- Added abort of in-flight AI requests on disconnect to prevent resource leaks

## Impact
- **Severity: Medium** - Disconnect logging was completely broken (threw TypeError silently). No cleanup of in-flight requests on client disconnect.

## Test plan
- [ ] Verify that connect/disconnect logging works correctly in both agent namespaces
- [ ] Verify that in-flight AI requests are properly aborted when a client disconnects
- [ ] Verify that chat and other socket events still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)