### PR TITLE
fix: null dereference crashes in productionAgent and uploadClip

### DIFF
--- a/src/agents/productionAgent/index.ts
+++ b/src/agents/productionAgent/index.ts
@@ -50,8 +50,11 @@ export async function runDecisionAI(ctx: AgentContext) {
 
   const projectInfo = await u.db("o_project").where("id", ctx.resTool.data.projectId).first();
   if (!projectInfo) throw new Error(`项目不存在，ID: ${ctx.resTool.data.projectId}`);
-  const [_, imageModelName] = projectInfo.imageModel!.split(/:(.+)/);
-  const [id, videoModelName] = projectInfo.videoModel!.split(/:(.+)/);
+  if (!projectInfo.imageModel || !projectInfo.videoModel) {
+    throw new Error(`项目未配置图像或视频模型，请先在项目设置中配置模型`);
+  }
+  const [_, imageModelName] = projectInfo.imageModel.split(/:(.+)/);
+  const [id, videoModelName] = projectInfo.videoModel.split(/:(.+)/);
   const models = await u.vendor.getModelList(id);
   if (!models.length) throw new Error(`项目使用的模型不存在，ID: ${projectInfo.videoModel}`);
   let videoMode = "";
@@ -147,8 +150,11 @@ async function createSubAgent(parentCtx: AgentContext) {
   if (!projectInfo) throw new Error(`项目不存在，ID: ${resTool.data.projectId}`);
   const artSkills = await createArtSkills(projectInfo?.artStyle!, projectInfo?.directorManual!);
 
-  const [_, imageModelName] = projectInfo.imageModel!.split(/:(.+)/);
-  const [id, videoModelName] = projectInfo.videoModel!.split(/:(.+)/);
+  if (!projectInfo.imageModel || !projectInfo.videoModel) {
+    throw new Error(`项目未配置图像或视频模型，请先在项目设置中配置模型`);
+  }
+  const [_, imageModelName] = projectInfo.imageModel.split(/:(.+)/);
+  const [id, videoModelName] = projectInfo.videoModel.split(/:(.+)/);
   const models = await u.vendor.getModelList(id);
   if (!models.length) throw new Error(`项目使用的模型不存在，ID: ${projectInfo.videoModel}`);
   // const findData = models.find((i: any) => i.modelName == videoModelName);

--- a/src/routes/assets/uploadClip.ts
+++ b/src/routes/assets/uploadClip.ts
@@ -39,7 +39,7 @@ export default router.post(
     const ext = getExtFromBase64(base64Data);
     const savePath = `/${projectId}/assets/${uuid()}.${ext}`;
 
-    await u.oss.writeFile(savePath, Buffer.from(base64Data.match(/base64,([A-Za-z0-9+/=]+)/)[1] ?? "", "base64"));
+    await u.oss.writeFile(savePath, Buffer.from(base64Data.match(/base64,([A-Za-z0-9+/=]+)/)?.[1] ?? "", "base64"));
     const [id] = await u.db("o_assets").insert({
       type: type,
       projectId: projectId,


### PR DESCRIPTION
## Summary
- **productionAgent/index.ts (lines 53-54, 150-151)**: `projectInfo.imageModel` and `projectInfo.videoModel` are nullable fields (`string | null`) but were accessed with non-null assertions (`!`). When a project hasn't configured its models yet, `.split()` throws `TypeError: Cannot read properties of null`. Added null checks with descriptive error messages.
- **uploadClip.ts (line 42)**: The regex `base64Data.match(...)` result was accessed with `[1]` without null-safety. If the base64 data is malformed, `.match()` returns `null`, causing `TypeError`. Fixed with optional chaining `?.[1]`.

## Impact
- **Severity: Medium** - Both bugs cause unhandled crashes (500 errors) under legitimate conditions (unconfigured project or malformed upload data)

## Test plan
- [ ] Verify that accessing a project without configured models shows a clear error instead of crashing
- [ ] Verify that uploading a valid clip still works correctly
- [ ] Test with malformed base64 data to ensure graceful error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)