### PR TITLE
fix: wrap cascading deletes in database transactions

### DIFF
--- a/src/routes/novel/batchDeleteNovel.ts
+++ b/src/routes/novel/batchDeleteNovel.ts
@@ -15,12 +15,15 @@ export default router.post(
     if (!ids.length) {
       return res.status(400).send(error("请先选择需要删除的内容"));
     }
-    const chapterData = await u.db("o_eventChapter").whereIn("novelId", ids);
-    await u.db("o_eventChapter").whereIn("novelId", ids).delete();
-    const eventIds = chapterData.map((i) => i.id);
-    if (eventIds.length) await u.db("o_event").whereIn("id", eventIds).delete();
 
-    await u.db("o_novel").whereIn("id", ids).del();
+    const chapterData = await u.db("o_eventChapter").whereIn("novelId", ids);
+    const eventIds = chapterData.map((i) => i.id);
+
+    await u.db.transaction(async (trx) => {
+      await trx("o_eventChapter").whereIn("novelId", ids).delete();
+      if (eventIds.length) await trx("o_event").whereIn("id", eventIds).delete();
+      await trx("o_novel").whereIn("id", ids).del();
+    });
 
     res.status(200).send(success({ message: "删除原文成功" }));
   },

--- a/src/routes/project/delProject.ts
+++ b/src/routes/project/delProject.ts
@@ -13,43 +13,45 @@ export default router.post(
   }),
   async (req, res) => {
     const { id } = req.body;
-    //删除项目
-    await u.db("o_project").where("id", id).delete();
-    await u.db("o_agentWorkData").where("projectId", id).delete();
-    //删除项目下的原文
-    await u.db("o_novel").where("projectId", id).delete();
-    // 删除项目下的剧本信息
-    const scriptData = await u.db("o_script").where("projectId", id).select("id");
-    const scriptIds = scriptData.map((item: any) => item.id);
-    if (scriptIds.length > 0) {
-      await u.db("o_scriptAssets").whereIn("scriptId", scriptIds).delete();
-    }
-    await u.db("o_script").where("projectId", id).delete();
-    // 删除项目下的任务
-    await u.db("o_tasks").where("projectId", id).delete();
-    // 删除项目下的分镜
-    const storyboardData = await u.db("o_storyboard").where("projectId", id).select("id");
-    const storyboardIds = storyboardData.map((item: any) => item.id);
-    if (storyboardIds.length > 0) {
-      await u.db("o_assets2Storyboard").whereIn("storyboardId", storyboardIds).delete();
-    }
-    await u.db("o_storyboard").where("projectId", id).delete();
-    //删除需要删除资产的归属图片
-    const assetsData = await u.db("o_assets").where("projectId", id).select("id");
-    const assetsIds = assetsData.map((item: any) => item.id);
-    if (assetsIds.length > 0) {
-      // 先将 o_assets.imageId 置空，解除对 o_image 的外键引用
-      await u.db("o_assets").whereIn("id", assetsIds).update({ imageId: null });
-      await u.db("o_image").whereIn("assetsId", assetsIds).delete();
-    }
-    // 删除项目下的资产
-    await u.db("o_assets").where("projectId", id).delete();
-    //删除项目下的视频轨道和视频
-    await u.db("o_videoTrack").where("projectId", id).delete();
-    await u.db("o_video").where("projectId", id).delete();
-    //删除项目下的资源
 
-    await u.db("memories").where("isolationKey", "like", `${id}:%`).delete();
+    await u.db.transaction(async (trx) => {
+      // 删除项目
+      await trx("o_project").where("id", id).delete();
+      await trx("o_agentWorkData").where("projectId", id).delete();
+      // 删除项目下的原文
+      await trx("o_novel").where("projectId", id).delete();
+      // 删除项目下的剧本信息
+      const scriptData = await trx("o_script").where("projectId", id).select("id");
+      const scriptIds = scriptData.map((item: any) => item.id);
+      if (scriptIds.length > 0) {
+        await trx("o_scriptAssets").whereIn("scriptId", scriptIds).delete();
+      }
+      await trx("o_script").where("projectId", id).delete();
+      // 删除项目下的任务
+      await trx("o_tasks").where("projectId", id).delete();
+      // 删除项目下的分镜
+      const storyboardData = await trx("o_storyboard").where("projectId", id).select("id");
+      const storyboardIds = storyboardData.map((item: any) => item.id);
+      if (storyboardIds.length > 0) {
+        await trx("o_assets2Storyboard").whereIn("storyboardId", storyboardIds).delete();
+      }
+      await trx("o_storyboard").where("projectId", id).delete();
+      // 删除需要删除资产的归属图片
+      const assetsData = await trx("o_assets").where("projectId", id).select("id");
+      const assetsIds = assetsData.map((item: any) => item.id);
+      if (assetsIds.length > 0) {
+        // 先将 o_assets.imageId 置空，解除对 o_image 的外键引用
+        await trx("o_assets").whereIn("id", assetsIds).update({ imageId: null });
+        await trx("o_image").whereIn("assetsId", assetsIds).delete();
+      }
+      // 删除项目下的资产
+      await trx("o_assets").where("projectId", id).delete();
+      // 删除项目下的视频轨道和视频
+      await trx("o_videoTrack").where("projectId", id).delete();
+      await trx("o_video").where("projectId", id).delete();
+      // 删除项目下的资源
+      await trx("memories").where("isolationKey", "like", `${id}:%`).delete();
+    });
 
     try {
       await u.oss.deleteDirectory(`${id}/`);

--- a/src/routes/script/delScript.ts
+++ b/src/routes/script/delScript.ts
@@ -13,27 +13,38 @@ export default router.post(
   }),
   async (req, res) => {
     const { ids } = req.body;
-    const scriptData = await u.db("o_script").whereIn("id", ids);
-    if (scriptData && scriptData.length) {
-      const scriptProjectId = new Set(scriptData.map((item) => item.projectId));
-      await u.db("o_agentWorkData").whereIn("projectId", Array.from(scriptProjectId)).whereIn("episodesId", ids).delete();
-    }
+
     const storyboardData = await u.db("o_storyboard").whereIn("scriptId", ids);
+
+    await u.db.transaction(async (trx) => {
+      const scriptData = await trx("o_script").whereIn("id", ids);
+      if (scriptData && scriptData.length) {
+        const scriptProjectId = new Set(scriptData.map((item) => item.projectId));
+        await trx("o_agentWorkData").whereIn("projectId", Array.from(scriptProjectId)).whereIn("episodesId", ids).delete();
+      }
+      if (storyboardData.length) {
+        const storyboardIds = storyboardData.map((item) => item.id);
+        await trx("o_assets2Storyboard").whereIn("storyboardId", storyboardIds).delete();
+      }
+      await trx("o_scriptAssets").whereIn("scriptId", ids).delete();
+      await trx("o_script").whereIn("id", ids).delete();
+      await trx("o_storyboard").whereIn("scriptId", ids).delete();
+      await trx("o_video").whereIn("scriptId", ids).delete();
+    });
+
+    // OSS 文件删除在事务外执行（不可回滚的外部资源）
     if (storyboardData.length) {
       await Promise.all(
         storyboardData.map(async (item) => {
           try {
-            item.filePath && (await u.oss.deleteFile(item.filePath));
-          } catch (e) {}
+            if (item.filePath) await u.oss.deleteFile(item.filePath);
+          } catch (e) {
+            console.error(`删除分镜文件失败: ${item.filePath}`, e);
+          }
         }),
       );
-      const storyboardIds = storyboardData.map((item) => item.id);
-      await u.db("o_assets2Storyboard").whereIn("storyboardId", storyboardIds).delete();
     }
-    await u.db("o_scriptAssets").whereIn("scriptId", ids).delete();
-    await u.db("o_script").whereIn("id", ids).delete();
-    await u.db("o_storyboard").whereIn("scriptId", ids).delete();
-    await u.db("o_video").whereIn("scriptId", ids).delete();
+
     res.status(200).send(success({ message: "删除剧本成功" }));
   },
 );


### PR DESCRIPTION
## Summary
- **delProject.ts**: ~12 sequential DELETE operations across 12+ tables were performed without a transaction. If any intermediate step failed, the database was left in an inconsistent state with a partially deleted project.
- **delScript.ts**: Multiple related deletes across `o_agentWorkData`, `o_scriptAssets`, `o_script`, `o_storyboard`, `o_assets2Storyboard`, and `o_video` were non-transactional.
- **batchDeleteNovel.ts**: Deletes across `o_eventChapter`, `o_event`, and `o_novel` were non-transactional.
- All three files now wrap database operations in Knex transactions for atomic rollback on failure.
- In `delScript.ts`, OSS file deletion is now performed outside the transaction (since external resources can't be rolled back) with proper error logging instead of silently swallowing errors.

## Impact
- **Severity: High** - Without transactions, partial deletes leave the database in an inconsistent state, causing orphaned records and potential foreign key violations

## Test plan
- [ ] Delete a project with associated data and verify all related records are removed
- [ ] Delete a script with associated data and verify all related records are removed
- [ ] Batch delete novels and verify chapter/event data is also removed
- [ ] Simulate a failure mid-delete and verify the database rolls back cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)