### PR TITLE
fix: error handler leaking internals and uncaught exception not exiting

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -127,10 +127,10 @@ export default async function startServe(randomPort: Boolean = false) {
 
   // 错误处理
   app.use((err: any, _: Request, res: Response, __: NextFunction) => {
-    res.locals.message = err.message;
-    res.locals.error = err;
     console.error(err);
-    res.status(err.status || 500).send(err);
+    const status = err.status || 500;
+    const message = status === 500 ? "服务器内部错误" : (err.message || "服务器内部错误");
+    res.status(status).send({ message });
   });
 
   const port = randomPort ? 0 : 10588;

--- a/src/err.ts
+++ b/src/err.ts
@@ -21,10 +21,13 @@ process.on("unhandledRejection", (reason, promise) => {
 });
 
 // 处理未捕获的异常
+// Node.js 文档明确建议：uncaughtException 后应退出进程，
+// 因为此时进程状态不可预测，继续运行可能导致数据损坏。
 process.on("uncaughtException", (error) => {
   console.error("[未捕获的异常]");
   console.error("错误名称:", error.name);
   console.error("错误消息:", error.message);
   console.error("堆栈信息:", error.stack);
   console.error("序列化详情:", JSON.stringify(serializeError(error), null, 2));
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
- **app.ts (line 133)**: The global Express error handler sent the raw error object directly to clients via `res.send(err)`, leaking stack traces, internal file paths, database queries, and other sensitive information. Replaced with a sanitized response that sends a generic "服务器内部错误" message for 500 errors, and only forwards the error message for non-500 status codes.
- **err.ts (lines 24-30)**: The `uncaughtException` handler logged errors but never exited the process. Per Node.js documentation, continuing after an uncaught exception is unsafe as the process state is undefined and can lead to data corruption. Added `process.exit(1)` to ensure the process restarts cleanly.

## Impact
- **Severity: High** - Error handler leaks sensitive internal details to attackers (information disclosure). Uncaught exception handler allows process to continue in undefined state (reliability/corruption risk).

## Test plan
- [ ] Trigger a 500 error and verify the response only contains a generic message without stack traces
- [ ] Verify that 4xx errors still return their error message
- [ ] Verify that the process exits on an uncaught exception (with proper logging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)