### PR TITLE
fix: omit empty image test references

### DIFF
--- a/src/routes/setting/vendorConfig/modelTest/imageTest.ts
+++ b/src/routes/setting/vendorConfig/modelTest/imageTest.ts
@@ -26,7 +26,7 @@ export default router.post(
 
       const reqFn = await u.Ai.Image(`${id}:${modelName}`).run({
         prompt: prompt,
-        referenceList: [{type:"image",base64:imageBase64}], //输入的图片提示词
+        ...(imageBase64 ? { referenceList: [{ type: "image", base64: imageBase64 }] } : {}), //输入的图片提示词
         size: "1K", // 图片尺寸
         aspectRatio: "16:9",
       });

--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -221,7 +221,9 @@ class AiText {
 function referenceList2imageBase642(id: string, input: any) {
   const version = u.vendor.getVendor(id).version;
   if (!version || isNaN(parseFloat(version)) || parseFloat(version) < 2.0) {
-    input.imageBase64 = input.referenceList.map((item: any) => item.base64);
+    if (Array.isArray(input.referenceList)) {
+      input.imageBase64 = input.referenceList.map((item: any) => item.base64).filter(Boolean);
+    }
     return input;
   }
   return input;


### PR DESCRIPTION
## Summary
- Avoids passing empty image references from the image model test endpoint
- Guards `referenceList` before mapping it in legacy vendor compatibility code
- Prevents undefined/empty reference values from breaking text-to-image tests

## Test Plan
- `NODE_ENV=prod npx tsx scripts/build.ts`
