### PR TITLE
fix: harden vendor config update endpoints

### DIFF
--- a/src/routes/setting/vendorConfig/enableVendor.ts
+++ b/src/routes/setting/vendorConfig/enableVendor.ts
@@ -8,11 +8,14 @@ export default router.post(
   "/",
   validateFields({
     id: z.string(),
-    enable: z.number(),
+    enable: z.union([z.number(), z.boolean()]),
   }),
   async (req, res) => {
     const { id, enable } = req.body;
-    await u.db("o_vendorConfig").where("id", id).update({ enable });
+    const existing = await u.db("o_vendorConfig").where("id", id).first("id");
+    if (!existing) return res.status(404).send(error(`供应商 ${id} 不存在，请先添加供应商`));
+
+    await u.db("o_vendorConfig").where("id", id).update({ enable: Number(enable) });
     res.status(200).send(success("更新成功"));
   },
 );

--- a/src/routes/setting/vendorConfig/updateCode.ts
+++ b/src/routes/setting/vendorConfig/updateCode.ts
@@ -76,17 +76,30 @@ export default router.post(
       if (!exports.videoRequest) return res.status(400).send(success("脚本文件必须导出视频请求对象"));
       if (!exports.vendor) return res.status(400).send(success("脚本文件必须导出vendor对象"));
       const vendor = exports.vendor;
+      if ((vendor.id as string).includes(":")) return res.status(400).send(error("id不能包含英文冒号"));
+      if (vendor.id !== id) return res.status(400).send(error(`请求 id(${id}) 与脚本 vendor.id(${vendor.id}) 不一致`));
       const result = vendorConfigSchema.safeParse(vendor);
       if (!result.success) {
         const errorMsg = result.error.issues.map((e) => `${e.path.join(".")}: ${e.message}`).join("; ");
         return res.status(400).send(error(`vendor配置校验失败: ${errorMsg}`));
       }
-      await u
-        .db("o_vendorConfig")
-        .where("id", id)
-        .update({
+
+      const existing = await u.db("o_vendorConfig").where("id", id).first("id");
+      if (existing) {
+        await u
+          .db("o_vendorConfig")
+          .where("id", id)
+          .update({
+            models: JSON.stringify(vendor.models ?? []),
+          });
+      } else {
+        await u.db("o_vendorConfig").insert({
+          id,
+          inputValues: JSON.stringify(vendor.inputValues ?? {}),
           models: JSON.stringify(vendor.models ?? []),
+          enable: id == "toonflow" ? 1 : 0,
         });
+      }
       u.vendor.writeCode(id, tsCode);
 
       res.status(200).send(success(result.data));

--- a/src/routes/setting/vendorConfig/updateVendorInputs.ts
+++ b/src/routes/setting/vendorConfig/updateVendorInputs.ts
@@ -10,16 +10,26 @@ export default router.post(
   "/",
   validateFields({
     id: z.string(),
-    inputValues: z.record(z.string(), z.string()),
+    inputValues: z.record(z.string(), z.unknown()),
   }),
   async (req, res) => {
     const { id, inputValues } = req.body;
+
+    const existing = await u.db("o_vendorConfig").where("id", id).first("inputValues");
+    if (!existing) return res.status(404).send(error(`供应商 ${id} 不存在，请先添加供应商`));
+
+    let previousInputValues = {};
+    try {
+      previousInputValues = JSON.parse(existing.inputValues ?? "{}");
+    } catch {
+      previousInputValues = {};
+    }
 
     await u
       .db("o_vendorConfig")
       .where("id", id)
       .update({
-        inputValues: JSON.stringify(inputValues),
+        inputValues: JSON.stringify({ ...previousInputValues, ...inputValues }),
       });
     res.status(200).send(success("更新成功"));
   },


### PR DESCRIPTION
## Summary
- Makes vendor config update endpoints return explicit errors when the vendor row is missing
- Merges `inputValues` updates instead of replacing the whole object
- Supports boolean `enable` values and validates `updateCode` id consistency before upserting

## Test Plan
- `NODE_ENV=prod npx tsx scripts/build.ts`
