### PR TITLE
fix: 修复 OpenAI 标准接口图片生成空结果

### DIFF
--- a/data/vendor/openai.ts
+++ b/data/vendor/openai.ts
@@ -53,7 +53,8 @@ interface VendorConfig {
 }
 interface ImageConfig {
   prompt: string;
-  imageBase64: string[];
+  referenceList?: { type: "image"; base64: string }[];
+  imageBase64?: string[];
   size: "1K" | "2K" | "4K";
   aspectRatio: `${number}:${number}`;
 }
@@ -142,7 +143,53 @@ const textRequest = (model: TextModel, think: boolean, thinkLevel: 0 | 1 | 2 | 3
   return createOpenAI({ baseURL: vendor.inputValues.baseUrl, apiKey }).chat(model.modelName);
 };
 const imageRequest = async (config: ImageConfig, model: ImageModel): Promise<string> => {
-  return "";
+  if (!vendor.inputValues.apiKey) throw new Error("缺少API Key");
+  if (!vendor.inputValues.baseUrl) throw new Error("缺少请求地址");
+
+  const referenceImages = config.referenceList ?? [];
+  if (referenceImages.length > 0 || (config.imageBase64?.length ?? 0) > 0) {
+    throw new Error("OpenAI图片生成暂不支持参考图，请使用纯文本提示词");
+  }
+
+  const apiKey = vendor.inputValues.apiKey.replace(/^Bearer\s+/i, "");
+  const baseUrl = vendor.inputValues.baseUrl.replace(/\/+$/, "");
+  const [ratioWidth, ratioHeight] = config.aspectRatio.split(":").map(Number);
+  const orientation = ratioWidth === ratioHeight ? "square" : ratioWidth > ratioHeight ? "landscape" : "portrait";
+  const imageSize = model.modelName === "dall-e-3"
+    ? { square: "1024x1024", landscape: "1792x1024", portrait: "1024x1792" }[orientation]
+    : model.modelName.startsWith("gpt-image")
+      ? { square: "1024x1024", landscape: "1536x1024", portrait: "1024x1536" }[orientation]
+      : "1024x1024";
+
+  try {
+    const response = await axios.post(
+      `${baseUrl}/images/generations`,
+      {
+        model: model.modelName,
+        prompt: config.prompt,
+        n: 1,
+        size: imageSize,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    const firstImage = response.data?.data?.[0];
+    if (typeof firstImage?.b64_json === "string" && firstImage.b64_json.length > 0) {
+      return firstImage.b64_json;
+    }
+    if (typeof firstImage?.url === "string" && firstImage.url.length > 0) {
+      return await urlToBase64(firstImage.url);
+    }
+    throw new Error("接口未返回 b64_json 或图片URL");
+  } catch (e: any) {
+    const message = e?.response?.data?.error?.message ?? e?.response?.data?.message ?? e?.message ?? String(e);
+    throw new Error(`OpenAI图片生成失败：${message}`);
+  }
 };
 const videoRequest = async (config: VideoConfig, model: VideoModel): Promise<string> => {
   return "";

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "dist:mac": "yarn build && electron-builder --mac",
     "dist:linux": "yarn build && electron-builder --linux",
     "debug:ai": "npx @ai-sdk/devtools",
+    "test:openai-image": "tsx --test tests/openai-image-adapter.test.ts",
     "license": "node scripts/license.ts",
     "vendor2json": "node scripts/vendor2json.ts"
   },

--- a/src/routes/assetsGenerate/batchGenerateImageAssets.ts
+++ b/src/routes/assetsGenerate/batchGenerateImageAssets.ts
@@ -127,7 +127,7 @@ export default router.post("/", validateFields(requestSchema), async (req, res) 
             relatedObjects: JSON.stringify(relatedObjects),
           },
         );
-        aiImage.save(imagePath);
+        await aiImage.save(imagePath);
 
         const imageData = await u.db("o_image").where("id", imageId).select("*").first();
         if (!imageData) return res.status(500).send("资产已被删除");

--- a/src/routes/assetsGenerate/generateAssets.ts
+++ b/src/routes/assetsGenerate/generateAssets.ts
@@ -113,7 +113,7 @@ export default router.post("/", validateFields(requestSchema), async (req, res) 
         relatedObjects: JSON.stringify(relatedObjects),
       },
     );
-    aiImage.save(imagePath);
+    await aiImage.save(imagePath);
     // 5. 更新记录 & 返回结果
     const imageData = await u.db("o_image").where("id", imageId).select("*").first();
     if (!imageData) return res.status(500).send("资产已被删除");

--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -255,7 +255,11 @@ class AiImage {
       const fn = await getVendorTemplateFn("imageRequest", mn);
       await referenceList2imageBase642(mn.split(/:(.+)/)[0], input);
       this.result = await fn(input);
+      if (typeof this.result !== "string" || this.result.trim().length === 0) {
+        throw new Error("图片供应商未返回图片数据");
+      }
       if (this.result.startsWith("http")) this.result = await urlToBase64(this.result);
+      if (this.result.trim().length === 0) throw new Error("图片供应商未返回图片数据");
       return this;
     };
     if (taskRecord) {

--- a/tests/openai-image-adapter.test.ts
+++ b/tests/openai-image-adapter.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+import { transform } from "sucrase";
+import { VM } from "vm2";
+
+type PostCall = { url: string; body: Record<string, unknown>; options: { headers: Record<string, string> } };
+
+function loadAdapter(responseData: unknown) {
+  const calls: PostCall[] = [];
+  const axios = {
+    post: async (url: string, body: Record<string, unknown>, options: PostCall["options"]) => {
+      calls.push({ url, body, options });
+      return { data: responseData };
+    },
+  };
+  const exports: Record<string, any> = {};
+  const source = fs.readFileSync("data/vendor/openai.ts", "utf8");
+  const code = transform(source, { transforms: ["typescript"] }).code.replace(/export\s*\{\s*\};?/g, "");
+  const vm = new VM({
+    sandbox: {
+      axios,
+      createOpenAI: () => ({ chat: () => ({}) }),
+      exports,
+      urlToBase64: async (url: string) => `downloaded:${url}`,
+    },
+  });
+  vm.run(code);
+  exports.vendor.inputValues = { apiKey: "Bearer test-key", baseUrl: "https://example.test/v1/" };
+  return { adapter: exports, calls };
+}
+
+const model = { name: "GPT Image", modelName: "gpt-image-2", type: "image", mode: ["text"] };
+const config = { prompt: "a cat", referenceList: [], size: "2K", aspectRatio: "16:9" };
+
+test("requests the OpenAI image generations endpoint and returns b64_json", async () => {
+  const { adapter, calls } = loadAdapter({ data: [{ b64_json: "aW1hZ2U=" }] });
+
+  const result = await adapter.imageRequest(config, model);
+
+  assert.equal(result, "aW1hZ2U=");
+  assert.equal(calls[0].url, "https://example.test/v1/images/generations");
+  assert.deepEqual(calls[0].body, { model: "gpt-image-2", prompt: "a cat", n: 1, size: "1536x1024" });
+  assert.equal(calls[0].options.headers.Authorization, "Bearer test-key");
+});
+
+test("downloads URL responses through the sandbox helper", async () => {
+  const { adapter } = loadAdapter({ data: [{ url: "https://images.test/result.png" }] });
+
+  const result = await adapter.imageRequest(config, model);
+
+  assert.equal(result, "downloaded:https://images.test/result.png");
+});
+
+test("rejects empty image responses", async () => {
+  const { adapter } = loadAdapter({ data: [{}] });
+
+  await assert.rejects(() => adapter.imageRequest(config, model), /未返回 b64_json 或图片URL/);
+});
+
+test("rejects reference images instead of silently ignoring them", async () => {
+  const { adapter } = loadAdapter({ data: [{ b64_json: "unused" }] });
+
+  await assert.rejects(
+    () => adapter.imageRequest({ ...config, referenceList: [{ type: "image", base64: "data:image/png;base64,eA==" }] }, model),
+    /暂不支持参考图/,
+  );
+});


### PR DESCRIPTION
## 问题

`data/vendor/openai.ts` 的 `imageRequest()` 当前固定返回空字符串。调用链继续把空字符串保存为 0 字节图片，并将任务标记为已完成；两个资产生成路由还缺少对 `save()` 的等待，存在写入完成前更新状态的竞态。

## 修复

- 实现 OpenAI 标准 `POST /images/generations` 请求
- 兼容 `data[0].b64_json` 和 `data[0].url` 两种返回格式
- 按模型和横竖方向映射 OpenAI 支持的图片尺寸
- 对空图片结果做通用失败保护，避免生成 0 字节文件后假成功
- 等待资产图片保存完成后再更新数据库状态
- 对当前不支持的参考图编辑给出明确错误，不再静默忽略

## 验证

- `yarn lint`
- `yarn test:openai-image`：4 项通过（Base64、URL、空响应、参考图）

未调用真实付费生图接口；适配器请求和响应通过沙盒 mock 验证。

关联 #230、#233。此 PR 与已关闭的 #217 不同，只处理可复现的 OpenAI 生图根因和必要的通用失败保护。