### PR TITLE
Add image editor toolbar save action

### DIFF
--- a/tests/editImageToolbarSave.test.mjs
+++ b/tests/editImageToolbarSave.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const artifactPath = fileURLToPath(new URL("../data/web/index.html", import.meta.url));
+const artifact = readFileSync(artifactPath, "utf8");
+
+test("内置前端包含图片编辑器工具栏保存入口", () => {
+  assert.match(artifact, /guide-save-btn/);
+  assert.match(artifact, /selectNodeToSave/);
+  assert.match(artifact, /请选择一个要保存的图片节点/);
+  assert.match(artifact, /Select exactly one image node to save/);
+});
+
+test("内置前端保留节点选取和画布交互控件", () => {
+  assert.match(artifact, /keepBottomLeftBtn/);
+  assert.match(artifact, /vue-flow__controls-interactive/);
+});


### PR DESCRIPTION
## What changed

- update the embedded Toonflow web bundle with the image-flow editor toolbar Save action
- add an artifact contract test for the visible save entry, localized validation, existing per-node select control, and Vue Flow interaction control

Source implementation: https://github.com/HBAI-Ltd/Toonflow-web/pull/28

## Why

Toonflow-app serves the compiled frontend from `data/web/index.html`. The source change alone would not reach the local application, so the corresponding production build must be embedded here.

## User impact

The image-flow editor now shows a labeled Save button in its top-left toolbar. Users select one image node and click Save. Invalid selections show a message without writing; valid saves reuse the existing image-flow and storyboard/asset update path.

## Validation

- embedded artifact test — 2/2 passed
- related provider, visual-manual, and artifact suite — 25 passed, 1 opt-in live video test skipped
- companion API suite — 6/6 passed
- `yarn lint` (`tsc --noEmit`) — passed
- current `http://127.0.0.1:10588/#/production` runtime — button visible in Chrome; no-selection validation passed without modifying project data

## Risk and rollback

This changes only the embedded web artifact and its focused test; there are no API or database changes. Roll back this commit to restore the previous bundle.
