### PR TITLE
决策agent不注入读取工作区的工具

### DIFF
--- a/src/agents/productionAgent/index.ts
+++ b/src/agents/productionAgent/index.ts
@@ -77,7 +77,7 @@ export async function runDecisionAI(ctx: AgentContext) {
     abortSignal,
     tools: {
       ...memory.getTools(),
-      ...useTools({ resTool: ctx.resTool, msg: ctx.msg }),
+      // ...useTools({ resTool: ctx.resTool, msg: ctx.msg }),// 不注入工具，防止决策层还是直接读工作区
       ...(await createSubAgent(ctx)),
     },
     onFinish: async (completion) => {

--- a/src/agents/scriptAgent/index.ts
+++ b/src/agents/scriptAgent/index.ts
@@ -71,7 +71,7 @@ export async function runDecisionAI(ctx: AgentContext) {
     abortSignal,
     tools: {
       ...memory.getTools(),
-      ...useTools({ resTool: ctx.resTool, msg: ctx.msg }),
+      // ...useTools({ resTool: ctx.resTool, msg: ctx.msg }),
       ...createSubAgent(ctx),
     },
     onFinish: async (completion) => {


### PR DESCRIPTION
重新生成分镜表、分镜面板时，虽然决策层提示词明确了不能读取工作区数据，但是代码层面却注入了工具，导致决策层依然有可能读取工作区信息，删除或者注释掉工具注入可以解决这个问题。