### PR TITLE
fix(workbench): recognize dated Seedance 2.0 models

### DIFF
--- a/src/lib/videoPromptReferences.ts
+++ b/src/lib/videoPromptReferences.ts
@@ -10,7 +10,7 @@ export interface VideoPromptAssetReference {
 
 export function isSeedance2Model(modelName: string | null | undefined): boolean {
   const normalized = (modelName ?? "").toLowerCase().replace(/[^a-z0-9]+/g, "-");
-  return /(?:^|-)seedance(?:-[a-z]+)*-?2(?:-0)?(?=$|-[a-z])/.test(normalized);
+  return /(?:^|-)seedance(?:-[a-z]+)*-?2(?:-0)?(?=$|-(?:[a-z]|\d{6}(?:$|-)))/.test(normalized);
 }
 
 export function resolveVideoReferenceMediaType(

--- a/tests/videoPromptReferences.test.ts
+++ b/tests/videoPromptReferences.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isSeedance2Model } from "../src/lib/videoPromptReferences";
+
+test("recognizes built-in Seedance 2.0 model identifiers", () => {
+  for (const model of [
+    "Seedance 2.0",
+    "doubao-seedance-2-0-260128",
+    "doubao-seedance-2-0-fast-260128",
+    "bytedance/seedance-2.0/reference-to-video",
+  ]) {
+    assert.equal(isSeedance2Model(model), true, model);
+  }
+});
+
+test("does not classify other models as Seedance 2.0", () => {
+  for (const model of [
+    "doubao-seedance-1-5-pro-251215",
+    "doubao-seedance-2-1-260128",
+    "doubao-seedream-2-0-260128",
+  ]) {
+    assert.equal(isSeedance2Model(model), false, model);
+  }
+});


### PR DESCRIPTION
## Summary

- Fixes: Selecting the built-in doubao-seedance-2-0-260128 model makes both single and batch prompt generation skip the Seedance 2 template and independent image, video, and audio reference mapping.
- Root cause: isSeedance2Model accepts a version boundary only at the end of the identifier or before an alphabetic suffix, so it rejects the repository's standard six-digit release-date suffix after 2-0.

## Regression evidence

- Before: `npx --yes --package node@24.11.1 --call 'node --import tsx --test tests/videoPromptReferences.test.ts'` exited `1`

- After: `npx --yes --package node@24.11.1 --call 'node --import tsx --test tests/videoPromptReferences.test.ts'` exited `0`

## Verification

- `npx --yes --package node@24.11.1 --call 'node --import tsx --test tests/*.test.ts'`
- `npx --yes --package node@24.11.1 --package yarn@1.22.22 --call 'yarn lint'`
- `npx --yes --package node@24.11.1 --package yarn@1.22.22 --call 'yarn build'`
- `git diff --cached --check`

## Scope

- 2 files changed, +26 / -1 lines
