### PR TITLE
修复：按实际输入模式选择视频提示词模板

### DIFF
--- a/src/lib/videoPromptTemplate.ts
+++ b/src/lib/videoPromptTemplate.ts
@@ -1,0 +1,33 @@
+import { isSeedance2Model } from "@/lib/videoPromptReferences";
+
+const FRAME_INPUT_MODES = new Set(["singleImage", "startEndRequired", "endFrameOptional", "startFrameOptional"]);
+
+function normalizeMode(mode: unknown): unknown {
+  if (typeof mode !== "string") return mode;
+  const value = mode.trim();
+  if (!value.startsWith("[")) return value;
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+export function selectVideoPromptTemplateFile(modelName: string, mode: unknown): string | null {
+  const normalizedMode = normalizeMode(mode);
+  const normalizedModel = modelName.toLowerCase();
+
+  if (Array.isArray(normalizedMode)) {
+    return isSeedance2Model(modelName) ? "seedance2Multi-parameterMode.md" : "universalMulti-parameterMode.md";
+  }
+
+  if (FRAME_INPUT_MODES.has(String(normalizedMode))) {
+    if (normalizedMode === "singleImage" && normalizedModel.includes("wan") && normalizedModel.includes("2.6")) {
+      return "wan2.6Single-imageFirstFrameMode.md";
+    }
+    return "universalFirstAndLastFrameMode.md";
+  }
+
+  return null;
+}

--- a/src/routes/production/workbench/batchGeneratePrompt.ts
+++ b/src/routes/production/workbench/batchGeneratePrompt.ts
@@ -12,6 +12,7 @@ import {
   isSeedance2Model,
   type VideoPromptAssetReference,
 } from "@/lib/videoPromptReferences";
+import { selectVideoPromptTemplateFile } from "@/lib/videoPromptTemplate";
 const router = express.Router();
 
 export default router.post(
@@ -58,23 +59,7 @@ export default router.post(
       if (!videoPromptGeneration) {
         const modelPromptRoot = u.getPath(["modelPrompt"]);
         const videoPromptDir = path.join(modelPromptRoot, "video");
-        const modelLower = (modelData ?? "").toLowerCase();
-
-        let fileName: string | null = null;
-
-        if (modelLower.includes("wan") && modelLower.includes("2.6")) {
-          // wan2.6 系列 => 单图首尾帧模式
-          fileName = "wan2.6Single-imageFirstFrameMode.md";
-        } else if (isSeedance2Model(modelLower)) {
-          // seedance 2.0 / 2-0 系列
-          fileName = "seedance2Multi-parameterMode.md";
-        } else if (mode === "startEndRequired" || mode === "endFrameOptional" || mode === "startFrameOptional") {
-          // body.mode 为首尾帧相关 => 通用首尾帧模式
-          fileName = "universalFirstAndLastFrameMode.md";
-        } else if (typeof mode === "string" && mode.startsWith('["') && mode.endsWith('"]')) {
-          // 其他 => 通用多参模式
-          fileName = "universalMulti-parameterMode.md";
-        }
+        const fileName = selectVideoPromptTemplateFile(modelData, mode);
         if (fileName) {
           try {
             const fullPath = path.join(videoPromptDir, fileName);

--- a/src/routes/production/workbench/generateVideoPrompt.ts
+++ b/src/routes/production/workbench/generateVideoPrompt.ts
@@ -11,6 +11,7 @@ import {
   isSeedance2Model,
   type VideoPromptAssetReference,
 } from "@/lib/videoPromptReferences";
+import { selectVideoPromptTemplateFile } from "@/lib/videoPromptTemplate";
 const router = express.Router();
 
 export default router.post(
@@ -125,23 +126,7 @@ export default router.post(
     if (!videoPromptGeneration) {
       const modelPromptRoot = u.getPath(["modelPrompt"]);
       const videoPromptDir = path.join(modelPromptRoot, "video");
-      const modelLower = (modelData ?? "").toLowerCase();
-
-      let fileName: string | null = null;
-
-      if (modelLower.includes("wan") && modelLower.includes("2.6")) {
-        // wan2.6 系列 => 单图首尾帧模式
-        fileName = "wan2.6Single-imageFirstFrameMode.md";
-      } else if (isSeedance2Model(modelData)) {
-        // seedance 2.0 / 2-0 系列
-        fileName = "seedance2Multi-parameterMode.md";
-      } else if (mode === "startEndRequired" || mode === "endFrameOptional" || mode === "startFrameOptional") {
-        // body.mode 为首尾帧相关 => 通用首尾帧模式
-        fileName = "universalFirstAndLastFrameMode.md";
-      } else if (typeof mode === "string" && mode.startsWith('["') && mode.endsWith('"]')) {
-        // 其他 => 通用多参模式
-        fileName = "universalMulti-parameterMode.md";
-      }
+      const fileName = selectVideoPromptTemplateFile(modelData, mode);
       if (fileName) {
         try {
           const fullPath = path.join(videoPromptDir, fileName);


### PR DESCRIPTION
## 问题

自动选择视频提示词模板时，现有逻辑先判断模型名称，再判断实际输入模式。这会让模型名称覆盖用户选择的输入方式，例如：

- Seedance 2.0 的首帧或单图模式仍命中 Seedance 多参考模板；
- Wan 2.6 的多参考模式仍命中 Wan 单图模板；
- 其他模型的 `singleImage` 模式无法命中通用帧输入模板；
- 带首尾空格的多参考 JSON 字符串可能无法识别。

错误模板会让提示词生成 Agent 使用与真实请求不一致的引用方式，例如在首帧模式中输出 `@图片N` 多参考指令。

## 改动

- 提取无数据库副作用的模板选择函数，统一单条和批量提示词生成的路由规则；
- 先识别多参考、单图、首帧、尾帧或首尾帧输入，再应用 Seedance 2.0 和 Wan 2.6 的模型特化；
- 同时兼容实际数组和 JSON 字符串形式的多参考模式，并处理字符串首尾空格；
- 保持 `o_modelPrompt` 中的用户手工绑定优先级不变，自动路由只在没有显式绑定时生效。

## 路由结果

| 输入方式 | 模型 | 模板 |
| --- | --- | --- |
| 多参考 | Seedance 2 系列 | Seedance 多参考模板 |
| 多参考 | 其他模型 | 通用多参考模板 |
| `singleImage` | Wan 2.6 | Wan 2.6 单图模板 |
| 单图、首帧、尾帧、首尾帧 | 其他组合 | 通用帧输入模板 |
| 纯文本或未知模式 | 任意模型 | 保持原有公共兜底 |

## 验证

- 临时回归脚本覆盖 11 组模型与输入模式组合，全部通过；测试脚本按项目要求未提交到 PR；
- `npm exec tsc -- --noEmit` 通过；
- 实际运行确认 Seedance 首帧命中通用帧模板、Seedance 多参考命中专用模板、Wan 单图命中专用模板、Wan 多参考命中通用多参考模板；
- `git diff --check` 通过。

## 范围

本 PR 不修改四份提示词模板正文，不修改数据库结构、供应商适配器、场景参考功能、更新日志或已编译前端产物。
