### PR TITLE
修复：生成视频提示词时读取当前轨道分镜

### DIFF
--- a/src/lib/videoPromptContext.ts
+++ b/src/lib/videoPromptContext.ts
@@ -1,0 +1,17 @@
+import type { Knex } from "knex";
+
+export interface VideoPromptStoryboard {
+  id: number;
+  videoDesc: string | null;
+  duration: string | null;
+}
+
+export async function getTrackStoryboardsForVideoPrompt(db: Knex, trackId: number, projectId: number): Promise<VideoPromptStoryboard[]> {
+  const rows = await db("o_storyboard")
+    .where({ trackId, projectId })
+    .orderBy("index", "asc")
+    .orderBy("id", "asc")
+    .select("id", "videoDesc", "duration");
+
+  return rows.filter((row: VideoPromptStoryboard) => row.videoDesc?.trim());
+}

--- a/src/routes/production/workbench/batchGeneratePrompt.ts
+++ b/src/routes/production/workbench/batchGeneratePrompt.ts
@@ -12,6 +12,7 @@ import {
   isSeedance2Model,
   type VideoPromptAssetReference,
 } from "@/lib/videoPromptReferences";
+import { getTrackStoryboardsForVideoPrompt } from "@/lib/videoPromptContext";
 const router = express.Router();
 
 export default router.post(
@@ -109,24 +110,9 @@ export default router.post(
         limit(async () => {
           // 查询参数
           const images = await Promise.all(
-            track.info.map(async (item: { id: number; sources: string; fileType?: "image" | "video" | "audio" }) => {
-              if (item.sources === "storyboard") {
-                // 查询分镜主信息
-                const storyboard = await u
-                  .db("o_storyboard")
-                  .where("o_storyboard.id", item.id)
-                  .select("videoDesc", "prompt", "track", "duration", "shouldGenerateImage")
-                  .first();
-                // 查询分镜关联的资产ID
-                const assetRows = await u.db("o_assets2Storyboard").where("storyboardId", item.id).orderBy("rowid").select("assetId");
-                const associateAssetsIds = assetRows.map((row: any) => row.assetId);
-                return {
-                  ...storyboard,
-                  associateAssetsIds,
-                  _type: "storyboard",
-                };
-              }
-              if (item.sources === "assets") {
+            track.info
+              .filter((item: { sources: string }) => item.sources === "assets")
+              .map(async (item: { id: number; sources: string; fileType?: "image" | "video" | "audio" }) => {
                 // 查询素材
                 const assetsData = await u
                   .db("o_assets")
@@ -139,13 +125,17 @@ export default router.post(
                   mediaType: item.fileType ?? assetsData?.storedFileType,
                   _type: "assets",
                 };
-              }
-            }),
+              }),
           );
 
-          // 拆分 assets 和 storyboard
+          // 参考资产由前端选择，剧情分镜始终以当前轨道的数据库记录为准。
           const assets: VideoPromptAssetReference[] = [];
-          const storyboard: any[] = [];
+          const storyboard = await getTrackStoryboardsForVideoPrompt(u.db, track.trackId, projectId);
+          if (!storyboard.length) {
+            const reason = "当前视频轨道没有可用的分镜文字";
+            await u.db("o_videoTrack").where({ id: track.trackId }).update({ state: "生成失败", reason });
+            return { trackId: track.trackId, error: reason };
+          }
           for (const item of images) {
             if (!item) continue;
             if (item._type === "assets")
@@ -155,15 +145,6 @@ export default router.post(
                 name: item.name,
                 filePath: item.filePath,
                 mediaType: item.mediaType,
-              });
-            if (item._type === "storyboard")
-              storyboard.push({
-                videoDesc: item.videoDesc,
-                prompt: item.prompt,
-                track: item.track,
-                duration: item.duration,
-                associateAssetsIds: item.associateAssetsIds,
-                shouldGenerateImage: item.shouldGenerateImage,
               });
           }
 

--- a/src/routes/production/workbench/generateVideoPrompt.ts
+++ b/src/routes/production/workbench/generateVideoPrompt.ts
@@ -11,6 +11,7 @@ import {
   isSeedance2Model,
   type VideoPromptAssetReference,
 } from "@/lib/videoPromptReferences";
+import { getTrackStoryboardsForVideoPrompt } from "@/lib/videoPromptContext";
 const router = express.Router();
 
 export default router.post(
@@ -35,24 +36,9 @@ export default router.post(
     });
     //查询参数
     const images = await Promise.all(
-      info.map(async (item: { id: number; sources: string; fileType?: "image" | "video" | "audio" }) => {
-        if (item.sources === "storyboard") {
-          // 查询分镜主信息
-          const storyboard = await u
-            .db("o_storyboard")
-            .where("o_storyboard.id", item.id)
-            .select("videoDesc", "prompt", "track", "duration", "shouldGenerateImage")
-            .first();
-          // 查询分镜关联的资产ID
-          const assetRows = await u.db("o_assets2Storyboard").where("storyboardId", item.id).orderBy("rowid").select("assetId");
-          const associateAssetsIds = assetRows.map((row: any) => row.assetId);
-          return {
-            ...storyboard,
-            associateAssetsIds,
-            _type: "storyboard", // 标记类型，便于后续区分
-          };
-        }
-        if (item.sources === "assets") {
+      info
+        .filter((item: { sources: string }) => item.sources === "assets")
+        .map(async (item: { id: number; sources: string; fileType?: "image" | "video" | "audio" }) => {
           // 查询素材
           const assetsData = await u
             .db("o_assets")
@@ -65,13 +51,17 @@ export default router.post(
             mediaType: item.fileType ?? assetsData?.storedFileType,
             _type: "assets", // 标记类型
           };
-        }
-      }),
+        }),
     );
 
-    // 拆分 assets 和 storyboard
+    // 参考资产由前端选择，剧情分镜始终以当前轨道的数据库记录为准。
     const assets: VideoPromptAssetReference[] = [];
-    const storyboard: any[] = [];
+    const storyboard = await getTrackStoryboardsForVideoPrompt(u.db, trackId, projectId);
+    if (!storyboard.length) {
+      const reason = "当前视频轨道没有可用的分镜文字";
+      await u.db("o_videoTrack").where({ id: trackId }).update({ state: "生成失败", reason });
+      return res.status(400).send(error(reason));
+    }
     for (const item of images) {
       if (!item) continue; // 忽略空
       if (item._type === "assets")
@@ -81,15 +71,6 @@ export default router.post(
           name: item.name,
           filePath: item.filePath,
           mediaType: item.mediaType,
-        });
-      if (item._type === "storyboard")
-        storyboard.push({
-          videoDesc: item.videoDesc,
-          prompt: item.prompt,
-          track: item.track,
-          duration: item.duration,
-          associateAssetsIds: item.associateAssetsIds,
-          shouldGenerateImage: item.shouldGenerateImage,
         });
     }
     const assetsNotAudioIds = assets.filter((i) => i.type == "audio").map((i) => i.id);


### PR DESCRIPTION
## 问题

生成视频提示词时，后端目前把客户端 `info` 中的分镜项当作剧情上下文来源。`info` 同时承担参考媒体选择，在单图、首尾帧等模式下可能只保留当前要上传的图片，因此当前轨道明明有完整分镜，提示词生成模型却可能收到空缺或不完整的剧情。

## 通用示例

假设某视频轨道在数据库中有两条分镜：

1. 角色推门进入会议室。
2. 角色走到桌旁放下文件。

当客户端本次只传一张会议室场景参考图时，修改前的后端只能从 `info` 找分镜，两条剧情都可能缺失；修改后会用 `projectId + trackId` 读取该轨道的两条真实分镜并按顺序传给提示词模型，而会议室场景图仍按客户端选择作为参考资产。

## 修改

- 新增无副作用的轨道分镜查询函数，按 `index`、`id` 稳定排序，并忽略空的 `videoDesc`。
- 单条和批量提示词生成统一从当前轨道读取分镜，不再依赖客户端媒体列表携带分镜 ID。
- 客户端 `info` 继续只决定角色、场景、道具、音频等参考资产。
- 当前轨道没有可用分镜文字时直接标记失败，避免消耗一次没有剧情上下文的 AI 请求。

## 不包含

- 不修改视频提示词模板或模型路由。
- 不修改数据库结构，也不迁移旧数据。
- 不包含前端改动、CHANGELOG、临时测试文件或构建产物。

## 兼容性与风险

工作台本身已经按 `trackId` 组织分镜，本修改沿用同一归属关系，并额外用 `projectId` 隔离项目。没有 `trackId` 的历史分镜不会被自动猜测归属；它们原本也不会出现在当前轨道的分镜媒体中。

## 验证

- 临时行为回归：覆盖当前项目/轨道过滤、其他项目/轨道隔离、空描述过滤、稳定排序和无分镜返回；通过（测试脚本未提交）。
- `npm run lint`：通过。
- `npm run build`：通过；生成的 `data/serve/app.js` 已恢复，未纳入提交。
- `git diff --cached --check`：通过。

关联 Issue：无，属于可独立复现的小型数据来源修复。